### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://msdevcampgur2017.visualstudio.com/5cc5bf13-f193-4cdf-90ef-0bc0f260a232/2a8a7b72-76ae-4ecd-9820-1a06c254d7f3/_apis/work/boardbadge/625980ec-9507-484d-b94c-02c92920f04b)](https://msdevcampgur2017.visualstudio.com/5cc5bf13-f193-4cdf-90ef-0bc0f260a232/_boards/board/t/2a8a7b72-76ae-4ecd-9820-1a06c254d7f3/Microsoft.RequirementCategory)
 
 # Contributing
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#16](https://msdevcampgur2017.visualstudio.com/5cc5bf13-f193-4cdf-90ef-0bc0f260a232/_workitems/edit/16). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.